### PR TITLE
ルートパス表示設定

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,2 +1,7 @@
 class PrototypesController < ApplicationController
+
+  def index
+    
+  end 
+
 end

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,10 +1,10 @@
 <div class="card">
-  <%= link_to image_tag("プロトタイプの画像", class: :card__img ), root_path%>
+  <%# <%= link_to image_tag("プロトタイプの画像", class: :card__img ), root_path%>
   <div class="card__body">
-    <%= link_to "プロトタイプのタイトル", root_path, class: :card__title%>
+    <%# <%= link_to "プロトタイプのタイトル", root_path, class: :card__title%> 
     <p class="card__summary">
       <%= "プロトタイプのキャッチコピー" %>
     </p>
-    <%= link_to "by プロトタイプの投稿者名", root_path, class: :card__user %>
+    <%# <%= link_to "by プロトタイプの投稿者名", root_path, class: :card__user %> %>
   </div>
 </div>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -8,6 +8,8 @@
     <%# // ログインしているときは上記を表示する %>
     <div class="card__wrapper">
       <%# 投稿機能実装後、部分テンプレートでプロトタイプ投稿一覧を表示する %>
+      <%= render partial: "prototype" %> 
+      <%# locals: { ローカル変数: ローカル変数} renderの引数。デプロイ実装(6/22)時点ではNameErrorのためコメントアウト %>
     </div>
   </div>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  # root to: 'tweets#index'
+  root to: 'prototypes#index'
   # resources :tweets
 end


### PR DESCRIPTION
## What
### デプロイ用初期設定

## Why
###やったこと
##### ルートパスに移動するとprototype.index.erbが表示できるようにする

1. ルーティング設定
　コメントアウトしていたroot 〜をコメントアウト解除、protostypesコントローラ／index Action

2. prototypes/indexの編集
 　11行目に10行目のコメントを参照しrenderメソッドを記載。引数のlocalは現段階では存在しないので12行目にコメントアウト

3. _prototype.index.htmlを編集
    変数指定がされておらずエラーになる部分をコメントアウト、追加修正はなし、設定後にコメントを解除すれば完成

4.localで動作確認ずみ

